### PR TITLE
Catch fetch errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -275,6 +275,7 @@ for (let i = 0; i < itemsToDownload.length; i++) {
 		continue;
 	}
 	logInfo(`Downloading file: ${targetFilename}`);
+    try {
 	const fileResponse = await autoRetry(fetch(logUrl(highestQuality.url)).then(checkHttpStatus));
 	const downloadProgress = new NodeFetchProgress(fileResponse, { throttle: 2500 });
 	downloadProgress.on('progress', p => console.log(`🧮 ${i}/${itemsToDownload.length} 🌐 ${targetFilename} 📁 ${p.doneh}/${p.totalh} ⏬ ${p.rateh}`));
@@ -300,6 +301,10 @@ for (let i = 0; i < itemsToDownload.length; i++) {
 		stateMediaItem.download_failed_at = new Date();
 		saveState(state);
 	});
+    } catch (err) {
+        logError(`Fetch error occured.`, err)
+        saveState(state);
+    }
 }
 
 let stateChangedInPostDownloadFileSizeCheck = false;


### PR DESCRIPTION
Hey Robin,

First of all, thanks a ton for sharing this tool! A few days ago I was worried I was going to have to download all my files from GoPro Cloud manually. Very grateful I did not have to do that.

When I first ran your script, it worked flawlessly at first, until it hit around 2000-2500 files, after which it kept hanging on an uncaught fetching error (see below). In this pull request, I have worked around it by adding a try-catch pair around the offending code.

Luuk

```
node:internal/process/esm_loader:97
    internalBinding('errors').triggerUncaughtException(
                              ^

Error: Task failed after 5 retries: Error: 404 Not Found
    at errorHandler (file:///gopro-cloud-media-downloader-master/utils.js:46:9)
    at tryCatcher (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/promise.js:725:18)
    at _drainQueueStep (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/async.js:102:5)
    at Async.drainQueues [as _onImmediate] (/gopro-cloud-media-downloader-master/node_modules/bluebird/js/release/async.js:15:14)
    at process.processImmediate (node:internal/timers:476:21)

Node.js v18.15.0
```